### PR TITLE
More tests for existing behavior

### DIFF
--- a/test/kiln/kiln_test.clj
+++ b/test/kiln/kiln_test.clj
@@ -43,6 +43,7 @@
     (stoke-coal k coal-2 store)
     (is (not (clay-fired? k fred)))
     (is (= (fire k fred) 6))
+    (is (= (fire k fred) 6) "value saved")
     (fire k mary!)
     (is (= @store [6]))
     (fire k sally!)

--- a/test/kiln/kiln_test.clj
+++ b/test/kiln/kiln_test.clj
@@ -119,6 +119,18 @@
     (is (= '[d c b] @cleanup-order)
         "cleanup should have happened in the reverse order of firing")))
 
+(deftest test-cleanup-after-firing-error
+  (let [k (new-kiln)
+        cleaned? (atom 0)
+        external-rs (clay :value 42 :cleanup (swap! cleaned? inc))
+        internal-rs (clay :value (do (?? external-rs) (throw+ ::whatever))
+                          :cleanup (swap! cleaned? - 50000))]
+    (is (try+ (fire k internal-rs), false
+              (catch (= % ::whatever) _
+                (cleanup-kiln-failure k), true)))
+    (is (= 1 @cleaned?)
+        "cleaned external-rs once, but never internal-rs")))
+
 (defcoal qqq)
 (defclay yyy)
 

--- a/test/kiln/kiln_test.clj
+++ b/test/kiln/kiln_test.clj
@@ -123,8 +123,10 @@
     (fire k bob!)
     (is (= @store [k]))))
 
-(declare loopy-clay)
+(declare loopy-clay embrace)
 (defclay loopy-clay :value (?? loopy-clay))
+(defclay deadly :value (?? embrace))
+(defclay embrace :value (?? deadly))
   
 (deftest test-loopy-clay
   (let [k (new-kiln)]
@@ -134,7 +136,10 @@
             (catch [:type :kiln-loop] {:keys [clay kiln]}
               (is (= clay loopy-clay))
               (is (= kiln k))
-              :exception-thrown))))))
+              :exception-thrown))))
+    (is (try+ (fire k deadly), false
+              (catch [:type :kiln-loop] _ true))
+        "detects mutual, as well as self-recursion")))
   
 (comment
 


### PR DESCRIPTION
Some tests for various evaluation semantics in `fire` and `cleanup-kiln-*`.  No concurrency tests; see #3 for more on that.
