### PR TITLE
Retry later on error

### DIFF
--- a/src/kiln/kiln.clj
+++ b/src/kiln/kiln.clj
@@ -41,7 +41,7 @@
           glazes (reverse (if-let [gl (:glaze clay)] (gl) nil))]
       ((reduce apply-glaze clay-fun glazes)))
     (finally
-     (dosync (alter (:vals kiln) assoc (:id clay) nil)))))
+     (dosync (alter (:vals kiln) dissoc (:id clay))))))
 
 (defn fire
   "Run the clay within the kiln to compute/retrieve its value."

--- a/test/kiln/kiln_test.clj
+++ b/test/kiln/kiln_test.clj
@@ -53,6 +53,17 @@
     (cleanup-kiln-success k)
     (is (= @store []))))
 
+(deftest test-errors-retry
+  (let [k (new-kiln)
+        tick (atom 0)
+        bomb (clay :value (do (swap! tick inc) (throw+ ::whatever)))]
+    (is (try+ (fire k bomb), false
+              (catch (= % ::whatever) _ true)))
+    (is (try+ (fire k bomb), false
+              (catch (= % ::whatever) _ true))
+        "happens again")
+    (is (= 2 @tick) "tried to compute again")))
+
 (deftest test-cleanups
   (let [k1 (new-kiln)
         k2 (new-kiln)


### PR DESCRIPTION
It was that

``` clojure
(fire k bomb) ;; error; assume you escape, and then
(fire k bomb) ;; returns nil, huh?
```

This makes the second `fire` try to eval the `:value` expression again.
